### PR TITLE
Fix: Support Quantity Field Updates for BOM Parts

### DIFF
--- a/api.py
+++ b/api.py
@@ -268,6 +268,30 @@ def remove_part_from_assembly(assembly_code: str, part_number: str):
     return jsonify({"error": f"Assembly {assembly_code} not found"}), 404
 
 
+@app.route("/api/assemblies/<assembly_code>/parts/<part_number>/quantity", methods=["PUT"])
+def update_assembly_part_quantity(assembly_code: str, part_number: str):
+    """Update the quantity of a part in an assembly's BOM.
+
+    Request body:
+    {
+        "quantity": 5
+    }
+    """
+    data = request.get_json()
+    if not data or "quantity" not in data:
+        return jsonify({"error": "quantity field required"}), 400
+
+    quantity = data["quantity"]
+    db = get_db()
+    try:
+        assembly = db.update_assembly_part_quantity(assembly_code, part_number, quantity)
+        if assembly:
+            return jsonify({"assembly": assembly, "message": f"Quantity updated to {quantity}"})
+        return jsonify({"error": f"Assembly {assembly_code} or part {part_number} not found"}), 404
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+
 @app.route("/api/assemblies/<assembly_code>/esps", methods=["GET"])
 def get_assembly_esps(assembly_code: str):
     """Find all ESPs that use a specific assembly."""

--- a/cli.py
+++ b/cli.py
@@ -245,6 +245,21 @@ def cmd_remove_part_from_assembly(args):
             sys.exit(1)
 
 
+def cmd_update_quantity(args):
+    """Update the quantity of a part in an assembly."""
+    with init_database() as db:
+        try:
+            assembly = db.update_assembly_part_quantity(args.assembly_code, args.part_number, args.quantity)
+            if assembly:
+                print_json({"assembly": assembly, "message": f"Quantity updated to {args.quantity}"})
+            else:
+                print(f"Assembly {args.assembly_code} or part {args.part_number} not found", file=sys.stderr)
+                sys.exit(1)
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+
 def cmd_add_assembly_to_esp(args):
     """Add an assembly to an ESP."""
     with init_database() as db:
@@ -411,6 +426,12 @@ def main():
     p.add_argument("assembly_code", help="Target assembly")
     p.add_argument("part_number", help="Part number to remove")
     p.set_defaults(cmd=cmd_remove_part_from_assembly)
+
+    p = asm_sub.add_parser("update-quantity", help="Update the quantity of a part in an assembly")
+    p.add_argument("assembly_code", help="Target assembly")
+    p.add_argument("part_number", help="Part number to update")
+    p.add_argument("quantity", type=int, help="New quantity (must be positive)")
+    p.set_defaults(cmd=cmd_update_quantity)
 
     # Stats command
     p = subparsers.add_parser("stats", help="Show database statistics")

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -428,6 +428,22 @@ def remove_part_from_assembly(assembly_code: str, part_number: str) -> dict | No
 
 
 @mcp.tool
+def update_assembly_part_quantity(assembly_code: str, part_number: str, quantity: int) -> dict | None:
+    """Update the quantity of a part in an assembly's BOM.
+
+    Args:
+        assembly_code: Target assembly
+        part_number: Part to update
+        quantity: New quantity (must be a positive integer)
+    """
+    with get_db() as db:
+        try:
+            return db.update_assembly_part_quantity(assembly_code, part_number, quantity)
+        except ValueError as e:
+            return {"error": str(e)}
+
+
+@mcp.tool
 def get_assembly_esps(assembly_code: str) -> list[dict]:
     """Find all ESPs that use a specific assembly.
 


### PR DESCRIPTION
## Summary
Implements GitHub Issue #1 - Support Quantity Field Updates for BOM Parts

- Fixed get_assembly() and get_all_assemblies() to include quantity field
- Added update_assembly_part_quantity() database function with validation
- Added REST API endpoint PUT /api/assemblies/<code>/parts/<pn>/quantity
- Added MCP tool update_assembly_part_quantity()
- Added CLI command assemblies update-quantity

## Test plan
- [ ] GET /api/assemblies/<code> returns quantity field in parts
- [ ] PUT /api/assemblies/<code>/parts/<pn>/quantity updates quantity
- [ ] CLI command python cli.py assemblies update-quantity works
- [ ] Error handling for invalid quantities (must be >=1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)